### PR TITLE
Add SerpAPI searches and improved actions

### DIFF
--- a/handlers/actions.py
+++ b/handlers/actions.py
@@ -1,22 +1,35 @@
 from google.cloud import firestore
+from handlers.search import search_flights, search_hotels
+from config import LODGING_LIMITS, get_region
 
-def post_flight_buttons(datos, state, event, client, doc_ref):
-    # Aquí deberías tener tu lógica de búsqueda de vuelos
-    # flights = search_google_flights(...) 
-    flights = []  # Modifica esta línea por la función real
-    # Suponiendo flights = [{"airline":..., "flight_number":..., ...}]
+def post_flight_buttons(flights, state, event, client, doc_ref):
     if not flights:
         return None
 
     state['flight_options'] = flights
+    state.setdefault('seen_flights', [])
+    state['seen_flights'].extend([f['id'] for f in flights])
     buttons = []
     for i, f in enumerate(flights):
         label = f"{f['airline']} {f['flight_number']} {f['departure_time']} → {f['arrival_time']} ${f.get('price', 'N/A')}"
         buttons.append({
             "type": "button",
             "text": {"type": "plain_text", "text": label[:75]},
-            "value": str(i)
+            "value": str(i),
+            "action_id": "flight_select"
         })
+    buttons.append({
+        "type": "button",
+        "text": {"type": "plain_text", "text": "Más opciones"},
+        "value": "more",
+        "action_id": "flight_reject"
+    })
+    buttons.append({
+        "type": "button",
+        "text": {"type": "plain_text", "text": "Sugerir vuelo"},
+        "value": "suggest",
+        "action_id": "flight_suggest"
+    })
     client.chat_postMessage(
         channel=event['channel'],
         text="Elige el vuelo que prefieres:",
@@ -29,23 +42,34 @@ def post_flight_buttons(datos, state, event, client, doc_ref):
     doc_ref.set(state)
     return flights
 
-def post_hotel_buttons(datos, state, event, client, doc_ref, max_lodging, area=None):
-    # Aquí deberías tener tu lógica de búsqueda de hoteles
-    # hotels = search_hotels(...)
-    hotels = []  # Modifica esta línea por la función real
-    # Suponiendo hotels = [{"name":..., "price":...}]
+def post_hotel_buttons(hotels, state, event, client, doc_ref, area=None):
     if not hotels:
         return None
 
     state['hotel_options'] = hotels
+    state.setdefault('seen_hotels', [])
+    state['seen_hotels'].extend([h['id'] for h in hotels])
     buttons = []
     for i, h in enumerate(hotels):
         label = f"{h['name']} ({h.get('price', 'N/A')})"
         buttons.append({
             "type": "button",
             "text": {"type": "plain_text", "text": label[:75]},
-            "value": str(i)
+            "value": str(i),
+            "action_id": "hotel_select"
         })
+    buttons.append({
+        "type": "button",
+        "text": {"type": "plain_text", "text": "Más opciones"},
+        "value": "more",
+        "action_id": "hotel_reject"
+    })
+    buttons.append({
+        "type": "button",
+        "text": {"type": "plain_text", "text": "Sugerir hotel"},
+        "value": "suggest",
+        "action_id": "hotel_suggest"
+    })
     client.chat_postMessage(
         channel=event['channel'],
         text="¿Tienes preferencia de zona o cadena hotelera? Si no, elige uno de estos hoteles:",
@@ -89,3 +113,107 @@ def register_actions(app):
             channel=body['channel']['id'],
             text=f"Hotel seleccionado: {selected_hotel['name']}. ¿Tienes viajero frecuente o seguimos?"
         )
+
+    @app.action("flight_reject")
+    def handle_flight_reject(ack, body, client):
+        ack()
+        user_id = body['user']['id']
+        doc_ref = db.collection('conversations').document(user_id)
+        state = doc_ref.get().to_dict()
+        state.setdefault('seen_flights', [])
+        state['seen_flights'].extend([f['id'] for f in state.get('flight_options', [])])
+        flights = search_flights(state['data'], exclude_ids=state['seen_flights'])
+        if flights:
+            post_flight_buttons(flights, state, {'channel': body['channel']['id']}, client, doc_ref)
+        else:
+            client.chat_postMessage(channel=body['channel']['id'], text="No encontré más vuelos disponibles.")
+
+    @app.action("hotel_reject")
+    def handle_hotel_reject(ack, body, client):
+        ack()
+        user_id = body['user']['id']
+        doc_ref = db.collection('conversations').document(user_id)
+        state = doc_ref.get().to_dict()
+        state.setdefault('seen_hotels', [])
+        state['seen_hotels'].extend([h['id'] for h in state.get('hotel_options', [])])
+        region = get_region(state['data']['destination'])
+        max_lodging = LODGING_LIMITS[state['level']][region]
+        region_area = state['data'].get('venue') or state['data']['destination']
+        hotels = search_hotels(state['data'], region_area, max_lodging, exclude_ids=state['seen_hotels'])
+        if hotels:
+            post_hotel_buttons(hotels, state, {'channel': body['channel']['id']}, client, doc_ref, area=region_area)
+        else:
+            client.chat_postMessage(channel=body['channel']['id'], text="No encontré más hoteles disponibles.")
+
+    @app.action("flight_suggest")
+    def handle_flight_suggest(ack, body, client):
+        ack()
+        client.views_open(
+            trigger_id=body["trigger_id"],
+            view={
+                "type": "modal",
+                "callback_id": "flight_suggest_submit",
+                "title": {"type": "plain_text", "text": "Sugerir vuelo"},
+                "submit": {"type": "plain_text", "text": "Enviar"},
+                "close": {"type": "plain_text", "text": "Cancelar"},
+                "blocks": [
+                    {
+                        "type": "input",
+                        "block_id": "flight_text",
+                        "element": {"type": "plain_text_input", "action_id": "val"},
+                        "label": {"type": "plain_text", "text": "Indica vuelo o aerolínea"}
+                    }
+                ]
+            }
+        )
+
+    @app.view("flight_suggest_submit")
+    def handle_flight_suggest_submit(ack, body, client):
+        ack()
+        user_id = body['user']['id']
+        flight_query = body['view']['state']['values']['flight_text']['val']['value']
+        doc_ref = db.collection('conversations').document(user_id)
+        state = doc_ref.get().to_dict()
+        flights = search_flights(state['data'], query=flight_query)
+        if flights:
+            post_flight_buttons(flights, state, {'channel': user_id}, client, doc_ref)
+        else:
+            client.chat_postMessage(channel=user_id, text="No encontré disponibilidad para ese vuelo.")
+
+    @app.action("hotel_suggest")
+    def handle_hotel_suggest(ack, body, client):
+        ack()
+        client.views_open(
+            trigger_id=body["trigger_id"],
+            view={
+                "type": "modal",
+                "callback_id": "hotel_suggest_submit",
+                "title": {"type": "plain_text", "text": "Sugerir hotel"},
+                "submit": {"type": "plain_text", "text": "Enviar"},
+                "close": {"type": "plain_text", "text": "Cancelar"},
+                "blocks": [
+                    {
+                        "type": "input",
+                        "block_id": "hotel_text",
+                        "element": {"type": "plain_text_input", "action_id": "val"},
+                        "label": {"type": "plain_text", "text": "Nombre o zona del hotel"}
+                    }
+                ]
+            }
+        )
+
+    @app.view("hotel_suggest_submit")
+    def handle_hotel_suggest_submit(ack, body, client):
+        ack()
+        user_id = body['user']['id']
+        hotel_query = body['view']['state']['values']['hotel_text']['val']['value']
+        doc_ref = db.collection('conversations').document(user_id)
+        state = doc_ref.get().to_dict()
+        region = get_region(state['data']['destination'])
+        max_lodging = LODGING_LIMITS[state['level']][region]
+        region_area = state['data'].get('venue') or state['data']['destination']
+        hotels = search_hotels(state['data'], region_area, max_lodging, query=hotel_query)
+        if hotels:
+            post_hotel_buttons(hotels, state, {'channel': user_id}, client, doc_ref, area=region_area)
+        else:
+            client.chat_postMessage(channel=user_id, text="No encontré disponibilidad para ese hotel.")

--- a/handlers/search.py
+++ b/handlers/search.py
@@ -1,6 +1,77 @@
 import requests
 from config import LODGING_LIMITS, get_region, SERPAPI_KEY
-from handlers.actions import post_flight_buttons, post_hotel_buttons
+
+SERP_ENDPOINT = "https://serpapi.com/search.json"
+
+def search_flights(datos, exclude_ids=None, query=None):
+    """Search flights using SerpAPI Google Flights."""
+    params = {"engine": "google_flights", "api_key": SERPAPI_KEY}
+    if query:
+        params["q"] = query
+    else:
+        params.update({
+            "departure_id": datos["origin"],
+            "arrival_id": datos["destination"],
+            "outbound_date": datos["start_date"],
+        })
+        if datos.get("return_date"):
+            params["return_date"] = datos["return_date"]
+    try:
+        resp = requests.get(SERP_ENDPOINT, params=params, timeout=20)
+        resp.raise_for_status()
+        data = resp.json()
+    except Exception:
+        return []
+
+    flights = []
+    for f in data.get("best_flights", []):
+        fid = f"{f.get('airline','')} {f.get('flight_number','')} {f.get('departing_at','')}"
+        if exclude_ids and fid in exclude_ids:
+            continue
+        flights.append({
+            "id": fid,
+            "airline": f.get("airline"),
+            "flight_number": f.get("flight_number"),
+            "departure_time": f.get("departing_at"),
+            "arrival_time": f.get("arriving_at"),
+            "price": f.get("price", {}).get("amount"),
+        })
+    return flights
+
+
+def search_hotels(datos, area, max_price, exclude_ids=None, query=None):
+    """Search hotels using SerpAPI Google Hotels."""
+    params = {
+        "engine": "google_hotels",
+        "api_key": SERPAPI_KEY,
+        "check_in_date": datos["start_date"],
+        "check_out_date": datos.get("return_date") or datos["start_date"],
+    }
+    if query:
+        params["q"] = query
+    else:
+        params["q"] = area
+    try:
+        resp = requests.get(SERP_ENDPOINT, params=params, timeout=20)
+        resp.raise_for_status()
+        data = resp.json()
+    except Exception:
+        return []
+
+    hotels = []
+    for h in data.get("hotels_results", []):
+        hid = h.get("name")
+        if exclude_ids and hid in exclude_ids:
+            continue
+        price = h.get("price_night", {}).get("extracted")
+        if price and price <= max_price:
+            hotels.append({
+                "id": hid,
+                "name": h.get("name"),
+                "price": price,
+                "link": h.get("link"),
+            })
+    return hotels
 
 def check_safety(area):
     url = "https://serpapi.com/search.json"
@@ -35,10 +106,16 @@ def find_better_area(area):
     return area
 
 def handle_search_and_buttons(datos, state, event, client, say, doc_ref, max_lodging_override=None):
+    from handlers.actions import post_flight_buttons, post_hotel_buttons
+
+    state.setdefault('seen_flights', [])
+    state.setdefault('seen_hotels', [])
+
     # Paso 1: Vuelos
     if not state.get('flight_selected'):
-        flights = post_flight_buttons(datos, state, event, client, doc_ref)
+        flights = search_flights(datos, exclude_ids=state['seen_flights'])
         if flights:
+            post_flight_buttons(flights, state, event, client, doc_ref)
             return True
         else:
             say("No encontré vuelos disponibles para esas fechas y rutas. Intenta con otros datos.")
@@ -57,10 +134,11 @@ def handle_search_and_buttons(datos, state, event, client, say, doc_ref, max_lod
             say(f"La zona {area} podría no ser segura: {info}. Buscaré hoteles en {better_area} en su lugar.")
             area = better_area
 
-        hotels = post_hotel_buttons(datos, state, event, client, doc_ref, max_lodging, area=area)
+        hotels = search_hotels(datos, area, max_lodging, exclude_ids=state['seen_hotels'])
         if hotels:
+            post_hotel_buttons(hotels, state, event, client, doc_ref, area=area)
             return True
         else:
-            say(f"No encontré hoteles en presupuesto. ¿Quieres buscar en otra zona o aumentar presupuesto?")
+            say("No encontré hoteles en presupuesto. ¿Quieres buscar en otra zona o aumentar presupuesto?")
             return True
     return False

--- a/handlers/summary.py
+++ b/handlers/summary.py
@@ -1,3 +1,6 @@
+import datetime
+
+
 def handle_summary(datos, state, user_id, say, doc_ref, client):
     if not datos.get('frequent_flyer'):
         say("¿Tienes número de viajero frecuente o membresía de hotel? Si no, responde 'no'.")
@@ -22,4 +25,13 @@ def handle_summary(datos, state, user_id, say, doc_ref, client):
     say("¡Listo! Tu solicitud ha sido enviada a Finanzas para la compra.")
 
     # Reset state
-    doc_ref.set({'data': {}, 'step': 0, 'level': state['level'], 'last_ts': state['last_ts']})
+    doc_ref.set({
+        'data': {},
+        'step': 0,
+        'level': state['level'],
+        'flight_options': [],
+        'hotel_options': [],
+        'seen_flights': [],
+        'seen_hotels': [],
+        'last_ts': state['last_ts'],
+    })

--- a/main.py
+++ b/main.py
@@ -42,7 +42,15 @@ def handle_message_events(event, say, client):
     user_id = event["user"]
     text = event.get("text", "").strip().lower()
     doc_ref = db.collection("conversations").document(user_id)
-    state = doc_ref.get().to_dict() or {"data": {}, "step": 0, "level": None, "flight_options": [], "hotel_options": []}
+    state = doc_ref.get().to_dict() or {
+        "data": {},
+        "step": 0,
+        "level": None,
+        "flight_options": [],
+        "hotel_options": [],
+        "seen_flights": [],
+        "seen_hotels": [],
+    }
 
     # TIMEOUT: Si han pasado más de 30 min, reinicia estado
     state = reset_state_if_timeout(state)

--- a/tests/test_timeouts.py
+++ b/tests/test_timeouts.py
@@ -52,5 +52,7 @@ def test_full_reset_when_timeout_exceeded(monkeypatch):
         "level": "L1",
         "flight_options": [],
         "hotel_options": [],
+        "seen_flights": [],
+        "seen_hotels": [],
         "last_ts": 2000,
     }

--- a/utils/timeouts.py
+++ b/utils/timeouts.py
@@ -6,7 +6,16 @@ def reset_state_if_timeout(state, timeout_seconds=1800):
     last_ts = state.get('last_ts')
     if last_ts and now_ts - last_ts > timeout_seconds:
         # Reinicia todo el flujo excepto el nivel (para no tener que leer la hoja de nuevo)
-        return {'data': {}, 'step': 0, 'level': state.get('level'), 'flight_options': [], 'hotel_options': [], 'last_ts': now_ts}
+        return {
+            'data': {},
+            'step': 0,
+            'level': state.get('level'),
+            'flight_options': [],
+            'hotel_options': [],
+            'seen_flights': [],
+            'seen_hotels': [],
+            'last_ts': now_ts,
+        }
     if not last_ts:
         state['last_ts'] = now_ts
     return state


### PR DESCRIPTION
## Summary
- implement real SerpAPI searches for flights and hotels
- add safety checks and improved search flow
- provide Slack actions for rejecting or suggesting results
- track seen options and reset state with new fields
- update tests for timeout reset

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68840e9c7bf0832599e660dd20e7a356