### PR TITLE
Add SerpAPI searches and improved actions

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -1,0 +1,40 @@
+# TravelBot Agent Prompt
+
+Este archivo documenta el prompt base y las reglas que utiliza TravelBot. El bot es el asistente de solicitudes internas de Creai. De momento solo gestiona viajes, pero la idea es expandirlo a más flujos.
+
+## Prompt para Gemini
+
+```
+Eres el asistente principal de solicitudes internas en Creai. Actualmente manejas viajes y debes conversar de forma breve sin ser redundante. Utiliza el historial incluido para recordar viajes pasados y saludar haciendo referencia a ellos si es apropiado.
+
+Debes extraer los siguientes datos esenciales del viaje, preguntando solo lo necesario:
+
+Origen: Ciudad de salida.
+Destino: Ciudad o lugar de llegada.
+Fecha de salida: acepta formatos flexibles y convierte al formato YYYY-MM-DD.
+Fecha de regreso: similar a la anterior o "null" si no aplica.
+Motivo del viaje.
+Venue: nombre del evento o "null".
+
+Reglas estrictas:
+- NO preguntes ni asumas nivel jerárquico, rol ni datos personales.
+- Si falta algún dato, pregunta solo por ese dato con una frase corta.
+- Si detectas ambigüedad, aclara sin asumir.
+- Interpreta fechas de manera flexible (por ejemplo "el próximo lunes").
+- Mantén la conversación enfocada y breve.
+- Una vez completos todos los datos, responde únicamente con un JSON válido con esos campos.
+```
+
+El historial de la conversación se agrega al final del prompt para que Gemini mantenga el contexto.
+
+## Reglas de la conversación
+
+- El bot debe enviar un resumen al canal designado de Finanzas una vez que el usuario haya seleccionado vuelo y hotel.
+- Se deben respetar los límites de la política de viajes definidos en `travel_policy.md`.
+- Si el usuario rechaza opciones de vuelo u hotel, se buscan nuevas sin repetir las ya mostradas.
+- El estado de cada conversación se guarda en Firestore para poder retomarlo o reiniciarlo tras un tiempo de inactividad.
+
+## Arquitectura futura
+
+El estado incluye un campo `request_type` para permitir otros flujos (por ejemplo compras de equipo u offboarding). Por ahora solo está implementado el flujo `travel`, pero la estructura de ruteo en `handlers/router.py` permite añadir nuevos manejadores.
+

--- a/config.py
+++ b/config.py
@@ -10,6 +10,7 @@ SLACK_SIGNING_SECRET = os.environ.get("SLACK_SIGNING_SECRET")
 SERPAPI_KEY = os.environ.get("SERPAPI_KEY")
 GEMINI_API_KEY = os.environ.get("GEMINI_API_KEY")
 GOOGLE_SHEET_ID = os.environ.get("GOOGLE_SHEET_ID")
+FINANCE_CHANNEL = os.environ.get("FINANCE_CHANNEL", "#travel-requests")
 
 # --- Validaciones para debug ---
 assert SLACK_BOT_TOKEN, "Falta SLACK_BOT_TOKEN"

--- a/handlers/actions.py
+++ b/handlers/actions.py
@@ -1,22 +1,35 @@
 from google.cloud import firestore
+from handlers.search import search_flights, search_hotels
+from config import LODGING_LIMITS, get_region
 
-def post_flight_buttons(datos, state, event, client, doc_ref):
-    # Aquí deberías tener tu lógica de búsqueda de vuelos
-    # flights = search_google_flights(...) 
-    flights = []  # Modifica esta línea por la función real
-    # Suponiendo flights = [{"airline":..., "flight_number":..., ...}]
+def post_flight_buttons(flights, state, event, client, doc_ref):
     if not flights:
         return None
 
     state['flight_options'] = flights
+    state.setdefault('seen_flights', [])
+    state['seen_flights'].extend([f['id'] for f in flights])
     buttons = []
     for i, f in enumerate(flights):
         label = f"{f['airline']} {f['flight_number']} {f['departure_time']} → {f['arrival_time']} ${f.get('price', 'N/A')}"
         buttons.append({
             "type": "button",
             "text": {"type": "plain_text", "text": label[:75]},
-            "value": str(i)
+            "value": str(i),
+            "action_id": "flight_select"
         })
+    buttons.append({
+        "type": "button",
+        "text": {"type": "plain_text", "text": "Más opciones"},
+        "value": "more",
+        "action_id": "flight_reject"
+    })
+    buttons.append({
+        "type": "button",
+        "text": {"type": "plain_text", "text": "Sugerir vuelo"},
+        "value": "suggest",
+        "action_id": "flight_suggest"
+    })
     client.chat_postMessage(
         channel=event['channel'],
         text="Elige el vuelo que prefieres:",
@@ -29,23 +42,34 @@ def post_flight_buttons(datos, state, event, client, doc_ref):
     doc_ref.set(state)
     return flights
 
-def post_hotel_buttons(datos, state, event, client, doc_ref, max_lodging, area=None):
-    # Aquí deberías tener tu lógica de búsqueda de hoteles
-    # hotels = search_hotels(...)
-    hotels = []  # Modifica esta línea por la función real
-    # Suponiendo hotels = [{"name":..., "price":...}]
+def post_hotel_buttons(hotels, state, event, client, doc_ref, area=None):
     if not hotels:
         return None
 
     state['hotel_options'] = hotels
+    state.setdefault('seen_hotels', [])
+    state['seen_hotels'].extend([h['id'] for h in hotels])
     buttons = []
     for i, h in enumerate(hotels):
         label = f"{h['name']} ({h.get('price', 'N/A')})"
         buttons.append({
             "type": "button",
             "text": {"type": "plain_text", "text": label[:75]},
-            "value": str(i)
+            "value": str(i),
+            "action_id": "hotel_select"
         })
+    buttons.append({
+        "type": "button",
+        "text": {"type": "plain_text", "text": "Más opciones"},
+        "value": "more",
+        "action_id": "hotel_reject"
+    })
+    buttons.append({
+        "type": "button",
+        "text": {"type": "plain_text", "text": "Sugerir hotel"},
+        "value": "suggest",
+        "action_id": "hotel_suggest"
+    })
     client.chat_postMessage(
         channel=event['channel'],
         text="¿Tienes preferencia de zona o cadena hotelera? Si no, elige uno de estos hoteles:",
@@ -89,3 +113,107 @@ def register_actions(app):
             channel=body['channel']['id'],
             text=f"Hotel seleccionado: {selected_hotel['name']}. ¿Tienes viajero frecuente o seguimos?"
         )
+
+    @app.action("flight_reject")
+    def handle_flight_reject(ack, body, client):
+        ack()
+        user_id = body['user']['id']
+        doc_ref = db.collection('conversations').document(user_id)
+        state = doc_ref.get().to_dict()
+        state.setdefault('seen_flights', [])
+        state['seen_flights'].extend([f['id'] for f in state.get('flight_options', [])])
+        flights = search_flights(state['data'], exclude_ids=state['seen_flights'])
+        if flights:
+            post_flight_buttons(flights, state, {'channel': body['channel']['id']}, client, doc_ref)
+        else:
+            client.chat_postMessage(channel=body['channel']['id'], text="No encontré más vuelos disponibles.")
+
+    @app.action("hotel_reject")
+    def handle_hotel_reject(ack, body, client):
+        ack()
+        user_id = body['user']['id']
+        doc_ref = db.collection('conversations').document(user_id)
+        state = doc_ref.get().to_dict()
+        state.setdefault('seen_hotels', [])
+        state['seen_hotels'].extend([h['id'] for h in state.get('hotel_options', [])])
+        region = get_region(state['data']['destination'])
+        max_lodging = LODGING_LIMITS[state['level']][region]
+        region_area = state['data'].get('venue') or state['data']['destination']
+        hotels = search_hotels(state['data'], region_area, max_lodging, exclude_ids=state['seen_hotels'])
+        if hotels:
+            post_hotel_buttons(hotels, state, {'channel': body['channel']['id']}, client, doc_ref, area=region_area)
+        else:
+            client.chat_postMessage(channel=body['channel']['id'], text="No encontré más hoteles disponibles.")
+
+    @app.action("flight_suggest")
+    def handle_flight_suggest(ack, body, client):
+        ack()
+        client.views_open(
+            trigger_id=body["trigger_id"],
+            view={
+                "type": "modal",
+                "callback_id": "flight_suggest_submit",
+                "title": {"type": "plain_text", "text": "Sugerir vuelo"},
+                "submit": {"type": "plain_text", "text": "Enviar"},
+                "close": {"type": "plain_text", "text": "Cancelar"},
+                "blocks": [
+                    {
+                        "type": "input",
+                        "block_id": "flight_text",
+                        "element": {"type": "plain_text_input", "action_id": "val"},
+                        "label": {"type": "plain_text", "text": "Indica vuelo o aerolínea"}
+                    }
+                ]
+            }
+        )
+
+    @app.view("flight_suggest_submit")
+    def handle_flight_suggest_submit(ack, body, client):
+        ack()
+        user_id = body['user']['id']
+        flight_query = body['view']['state']['values']['flight_text']['val']['value']
+        doc_ref = db.collection('conversations').document(user_id)
+        state = doc_ref.get().to_dict()
+        flights = search_flights(state['data'], query=flight_query)
+        if flights:
+            post_flight_buttons(flights, state, {'channel': user_id}, client, doc_ref)
+        else:
+            client.chat_postMessage(channel=user_id, text="No encontré disponibilidad para ese vuelo.")
+
+    @app.action("hotel_suggest")
+    def handle_hotel_suggest(ack, body, client):
+        ack()
+        client.views_open(
+            trigger_id=body["trigger_id"],
+            view={
+                "type": "modal",
+                "callback_id": "hotel_suggest_submit",
+                "title": {"type": "plain_text", "text": "Sugerir hotel"},
+                "submit": {"type": "plain_text", "text": "Enviar"},
+                "close": {"type": "plain_text", "text": "Cancelar"},
+                "blocks": [
+                    {
+                        "type": "input",
+                        "block_id": "hotel_text",
+                        "element": {"type": "plain_text_input", "action_id": "val"},
+                        "label": {"type": "plain_text", "text": "Nombre o zona del hotel"}
+                    }
+                ]
+            }
+        )
+
+    @app.view("hotel_suggest_submit")
+    def handle_hotel_suggest_submit(ack, body, client):
+        ack()
+        user_id = body['user']['id']
+        hotel_query = body['view']['state']['values']['hotel_text']['val']['value']
+        doc_ref = db.collection('conversations').document(user_id)
+        state = doc_ref.get().to_dict()
+        region = get_region(state['data']['destination'])
+        max_lodging = LODGING_LIMITS[state['level']][region]
+        region_area = state['data'].get('venue') or state['data']['destination']
+        hotels = search_hotels(state['data'], region_area, max_lodging, query=hotel_query)
+        if hotels:
+            post_hotel_buttons(hotels, state, {'channel': user_id}, client, doc_ref, area=region_area)
+        else:
+            client.chat_postMessage(channel=user_id, text="No encontré disponibilidad para ese hotel.")

--- a/handlers/extract.py
+++ b/handlers/extract.py
@@ -8,9 +8,9 @@ genai.configure(api_key=GEMINI_API_KEY)
 
 # Prompt persistente (pon tu prompt aquí)
 GEMINI_PROMPT = """
-Eres un asistente especializado en reservas de viajes de negocio, amigable y profesional. Tu objetivo es guiar la conversación de manera natural y fluida para recopilar información del usuario sin ser invasivo.
+Eres el asistente principal de solicitudes internas en Creai. Actualmente gestionas viajes, pero más adelante atenderás otras peticiones. Conversa de forma breve y profesional sin repetir información de manera innecesaria.
 
-Tu tarea principal es extraer los siguientes datos esenciales, preguntando solo lo necesario y de forma conversacional:
+Debes extraer los siguientes datos esenciales del viaje conversando solo lo necesario:
 
 Origen: Ciudad de salida (por ejemplo, "Madrid" o "Nueva York").
 Destino: Ciudad o lugar de llegada.
@@ -25,6 +25,7 @@ Si falta algún dato, pregunta SOLO por ese dato específico con una pregunta co
 Si detectas ambigüedad (como fechas vagas, destinos múltiples o formatos no estándar), pregunta para aclarar de inmediato sin asumir (ejemplo: "¿Te refieres a París en Francia o París en Texas?" o "¿La fecha de salida es el 25 de julio de este año?").
 Parsea fechas de manera flexible y humana: interpreta expresiones como "el próximo lunes", "en dos semanas" o formatos informales basándote en la fecha actual (25 de julio de 2025). Si es ambiguo, aclara.
 Mantén la conversación corta y enfocada; no agregues chit-chat innecesario a menos que el usuario lo inicie.
+Si conoces viajes o preferencias previas del usuario gracias al historial incluido en el prompt, puedes saludar haciendo referencia a ellos de manera natural.
 Si el usuario proporciona datos extra o corrige información, actualiza internamente y confirma sutilmente.
 Una vez que tengas TODOS los datos completos y sin ambigüedades, termina la conversación respondiendo SOLO con un JSON válido en este formato exacto (sin explicaciones, sin texto adicional):
 {

--- a/handlers/router.py
+++ b/handlers/router.py
@@ -1,0 +1,31 @@
+from handlers.extract import handle_extract_data
+from handlers.search import handle_search_and_buttons
+from handlers.summary import handle_summary
+
+
+def determine_request_type(text: str) -> str:
+    text = text.lower()
+    if any(word in text for word in ["equipo", "laptop", "computadora"]):
+        return "equipment"
+    if "offboarding" in text or "baja" in text:
+        return "offboarding"
+    return "travel"
+
+
+def handle_travel(event, say, client, state, doc_ref, user_id):
+    text = event.get("text", "")
+    datos = handle_extract_data(text, say, state, doc_ref, user_id)
+    if datos is None:
+        return
+    if handle_search_and_buttons(datos, state, event, client, say, doc_ref):
+        return
+    handle_summary(datos, state, user_id, say, doc_ref, client)
+
+
+def handle_request(event, say, client, state, doc_ref, user_id):
+    request_type = state.get("request_type", "travel")
+    if request_type == "travel":
+        handle_travel(event, say, client, state, doc_ref, user_id)
+    else:
+        say(f"Aún no gestiono solicitudes de {request_type}. Próximamente podré ayudarte.")
+

--- a/handlers/search.py
+++ b/handlers/search.py
@@ -1,6 +1,77 @@
 import requests
 from config import LODGING_LIMITS, get_region, SERPAPI_KEY
-from handlers.actions import post_flight_buttons, post_hotel_buttons
+
+SERP_ENDPOINT = "https://serpapi.com/search.json"
+
+def search_flights(datos, exclude_ids=None, query=None):
+    """Search flights using SerpAPI Google Flights."""
+    params = {"engine": "google_flights", "api_key": SERPAPI_KEY}
+    if query:
+        params["q"] = query
+    else:
+        params.update({
+            "departure_id": datos["origin"],
+            "arrival_id": datos["destination"],
+            "outbound_date": datos["start_date"],
+        })
+        if datos.get("return_date"):
+            params["return_date"] = datos["return_date"]
+    try:
+        resp = requests.get(SERP_ENDPOINT, params=params, timeout=20)
+        resp.raise_for_status()
+        data = resp.json()
+    except Exception:
+        return []
+
+    flights = []
+    for f in data.get("best_flights", []):
+        fid = f"{f.get('airline','')} {f.get('flight_number','')} {f.get('departing_at','')}"
+        if exclude_ids and fid in exclude_ids:
+            continue
+        flights.append({
+            "id": fid,
+            "airline": f.get("airline"),
+            "flight_number": f.get("flight_number"),
+            "departure_time": f.get("departing_at"),
+            "arrival_time": f.get("arriving_at"),
+            "price": f.get("price", {}).get("amount"),
+        })
+    return flights
+
+
+def search_hotels(datos, area, max_price, exclude_ids=None, query=None):
+    """Search hotels using SerpAPI Google Hotels."""
+    params = {
+        "engine": "google_hotels",
+        "api_key": SERPAPI_KEY,
+        "check_in_date": datos["start_date"],
+        "check_out_date": datos.get("return_date") or datos["start_date"],
+    }
+    if query:
+        params["q"] = query
+    else:
+        params["q"] = area
+    try:
+        resp = requests.get(SERP_ENDPOINT, params=params, timeout=20)
+        resp.raise_for_status()
+        data = resp.json()
+    except Exception:
+        return []
+
+    hotels = []
+    for h in data.get("hotels_results", []):
+        hid = h.get("name")
+        if exclude_ids and hid in exclude_ids:
+            continue
+        price = h.get("price_night", {}).get("extracted")
+        if price and price <= max_price:
+            hotels.append({
+                "id": hid,
+                "name": h.get("name"),
+                "price": price,
+                "link": h.get("link"),
+            })
+    return hotels
 
 def check_safety(area):
     url = "https://serpapi.com/search.json"
@@ -35,10 +106,16 @@ def find_better_area(area):
     return area
 
 def handle_search_and_buttons(datos, state, event, client, say, doc_ref, max_lodging_override=None):
+    from handlers.actions import post_flight_buttons, post_hotel_buttons
+
+    state.setdefault('seen_flights', [])
+    state.setdefault('seen_hotels', [])
+
     # Paso 1: Vuelos
     if not state.get('flight_selected'):
-        flights = post_flight_buttons(datos, state, event, client, doc_ref)
+        flights = search_flights(datos, exclude_ids=state['seen_flights'])
         if flights:
+            post_flight_buttons(flights, state, event, client, doc_ref)
             return True
         else:
             say("No encontré vuelos disponibles para esas fechas y rutas. Intenta con otros datos.")
@@ -57,10 +134,11 @@ def handle_search_and_buttons(datos, state, event, client, say, doc_ref, max_lod
             say(f"La zona {area} podría no ser segura: {info}. Buscaré hoteles en {better_area} en su lugar.")
             area = better_area
 
-        hotels = post_hotel_buttons(datos, state, event, client, doc_ref, max_lodging, area=area)
+        hotels = search_hotels(datos, area, max_lodging, exclude_ids=state['seen_hotels'])
         if hotels:
+            post_hotel_buttons(hotels, state, event, client, doc_ref, area=area)
             return True
         else:
-            say(f"No encontré hoteles en presupuesto. ¿Quieres buscar en otra zona o aumentar presupuesto?")
+            say("No encontré hoteles en presupuesto. ¿Quieres buscar en otra zona o aumentar presupuesto?")
             return True
     return False

--- a/handlers/summary.py
+++ b/handlers/summary.py
@@ -1,3 +1,7 @@
+import datetime
+from config import FINANCE_CHANNEL, db
+
+
 def handle_summary(datos, state, user_id, say, doc_ref, client):
     if not datos.get('frequent_flyer'):
         say("¿Tienes número de viajero frecuente o membresía de hotel? Si no, responde 'no'.")
@@ -18,8 +22,22 @@ def handle_summary(datos, state, user_id, say, doc_ref, client):
         f"- Hotel: {state.get('hotel_selected')}\n"
         f"- Viajero Frecuente: {datos.get('frequent_flyer','No')}\n"
     )
-    client.chat_postMessage(channel='#travel-requests', text=summary)
+    client.chat_postMessage(channel=FINANCE_CHANNEL, text=summary)
     say("¡Listo! Tu solicitud ha sido enviada a Finanzas para la compra.")
 
+    # Guardar ultimo destino en el perfil del usuario
+    profile_ref = db.collection("profiles").document(user_id)
+    profile_ref.set({"last_destination": datos["destination"]}, merge=True)
+
     # Reset state
-    doc_ref.set({'data': {}, 'step': 0, 'level': state['level'], 'last_ts': state['last_ts']})
+    doc_ref.set({
+        'data': {},
+        'step': 0,
+        'level': state['level'],
+        'request_type': 'travel',
+        'flight_options': [],
+        'hotel_options': [],
+        'seen_flights': [],
+        'seen_hotels': [],
+        'last_ts': state['last_ts'],
+    })

--- a/handlers/welcome.py
+++ b/handlers/welcome.py
@@ -1,11 +1,18 @@
 import re
 import datetime
+from config import db
 
-def handle_welcome(text, say, state, doc_ref):
+def handle_welcome(text, say, state, doc_ref, user_id):
     now_ts = datetime.datetime.utcnow().timestamp()
     # Detectar saludo típico al inicio
     if re.search(r'\b(hola|buen[oa]s?|hey|hi)\b', text, re.IGNORECASE):
-        say("¡Hola! 👋 Soy TravelBot, ¿en qué puedo ayudarte con tu viaje?")
+        profile_ref = db.collection("profiles").document(user_id)
+        profile = profile_ref.get().to_dict() or {}
+        last_dest = profile.get("last_destination")
+        if last_dest:
+            say(f"¡Hola! 👋 ¿Cómo te fue en {last_dest}? ¿En qué puedo ayudarte hoy?")
+        else:
+            say("¡Hola! 👋 Soy TravelBot, ¿en qué puedo ayudarte con tu viaje?")
         state['last_ts'] = now_ts
         doc_ref.set(state)
         return True

--- a/main.py
+++ b/main.py
@@ -7,10 +7,8 @@ from google.cloud import firestore
 
 from config import SLACK_BOT_TOKEN, SLACK_SIGNING_SECRET, db
 from handlers.welcome import handle_welcome
-from handlers.extract import handle_extract_data
-from handlers.search import handle_search_and_buttons
 from handlers.actions import register_actions
-from handlers.summary import handle_summary
+from handlers.router import determine_request_type, handle_request
 from utils.timeouts import reset_state_if_timeout
 
 # Configuración de la app de Slack
@@ -42,23 +40,26 @@ def handle_message_events(event, say, client):
     user_id = event["user"]
     text = event.get("text", "").strip().lower()
     doc_ref = db.collection("conversations").document(user_id)
-    state = doc_ref.get().to_dict() or {"data": {}, "step": 0, "level": None, "flight_options": [], "hotel_options": []}
+    state = doc_ref.get().to_dict() or {
+        "data": {},
+        "step": 0,
+        "level": None,
+        "request_type": "travel",
+        "flight_options": [],
+        "hotel_options": [],
+        "seen_flights": [],
+        "seen_hotels": [],
+    }
 
     # TIMEOUT: Si han pasado más de 30 min, reinicia estado
     state = reset_state_if_timeout(state)
 
+    if not state.get("request_type"):
+        state["request_type"] = determine_request_type(text)
+        doc_ref.set(state)
+
     # 1. Bienvenida
-    if handle_welcome(text, say, state, doc_ref):
+    if handle_welcome(text, say, state, doc_ref, user_id):
         return
 
-    # 2. Extracción y petición de datos mínimos
-    datos = handle_extract_data(text, say, state, doc_ref, user_id)
-    if datos is None:
-        return
-
-    # 3. Búsqueda de vuelos/hoteles y manejo de botones
-    if handle_search_and_buttons(datos, state, event, client, say, doc_ref):
-        return
-
-    # 4. Resumen final, enviar a Finanzas
-    handle_summary(datos, state, user_id, say, doc_ref, client)
+    handle_request(event, say, client, state, doc_ref, user_id)

--- a/tests/test_timeouts.py
+++ b/tests/test_timeouts.py
@@ -40,6 +40,7 @@ def test_full_reset_when_timeout_exceeded(monkeypatch):
         "data": {"a": 1},
         "step": 2,
         "level": "L1",
+        "request_type": "travel",
         "flight_options": [1],
         "hotel_options": [2],
         "last_ts": 100,
@@ -50,7 +51,10 @@ def test_full_reset_when_timeout_exceeded(monkeypatch):
         "data": {},
         "step": 0,
         "level": "L1",
+        "request_type": "travel",
         "flight_options": [],
         "hotel_options": [],
+        "seen_flights": [],
+        "seen_hotels": [],
         "last_ts": 2000,
     }

--- a/utils/timeouts.py
+++ b/utils/timeouts.py
@@ -6,7 +6,17 @@ def reset_state_if_timeout(state, timeout_seconds=1800):
     last_ts = state.get('last_ts')
     if last_ts and now_ts - last_ts > timeout_seconds:
         # Reinicia todo el flujo excepto el nivel (para no tener que leer la hoja de nuevo)
-        return {'data': {}, 'step': 0, 'level': state.get('level'), 'flight_options': [], 'hotel_options': [], 'last_ts': now_ts}
+        return {
+            'data': {},
+            'step': 0,
+            'level': state.get('level'),
+            'request_type': state.get('request_type', 'travel'),
+            'flight_options': [],
+            'hotel_options': [],
+            'seen_flights': [],
+            'seen_hotels': [],
+            'last_ts': now_ts,
+        }
     if not last_ts:
         state['last_ts'] = now_ts
     return state


### PR DESCRIPTION
## Summary
- implement real SerpAPI searches for flights and hotels
- add safety checks and improved search flow
- provide Slack actions for rejecting or suggesting results
- track seen options and reset state with new fields
- update tests for timeout reset
- route requests for future workflows and add finance channel
- document the agent prompt

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68840e9c7bf0832599e660dd20e7a356