### PR TITLE
Improve hotels search parsing

### DIFF
--- a/config.py
+++ b/config.py
@@ -11,6 +11,7 @@ SERPAPI_KEY = os.environ.get("SERPAPI_KEY")
 GEMINI_API_KEY = os.environ.get("GEMINI_API_KEY")
 GOOGLE_SHEET_ID = os.environ.get("GOOGLE_SHEET_ID")
 FINANCE_CHANNEL = os.environ.get("FINANCE_CHANNEL", "#travel-requests")
+SERP_DEEP_SEARCH = os.environ.get("SERP_DEEP_SEARCH", "false").lower() == "true"
 
 # --- Validaciones para debug ---
 assert SLACK_BOT_TOKEN, "Falta SLACK_BOT_TOKEN"

--- a/handlers/search.py
+++ b/handlers/search.py
@@ -1,16 +1,40 @@
 import re
 import requests
 import airportsdata
-from config import LODGING_LIMITS, get_region, SERPAPI_KEY
+from config import LODGING_LIMITS, get_region, SERPAPI_KEY, SERP_DEEP_SEARCH
 
 SERP_ENDPOINT = "https://serpapi.com/search.json"
 AIRPORTS = airportsdata.load("IATA")
+# Common aliases that don't directly map to a city name in airportsdata
+CITY_ALIASES = {
+    "CDMX": "MEX",
+    "CIUDAD DE MEXICO": "MEX",
+    "CIUDAD DE MÉXICO": "MEX",
+}
 
 
 def _city_to_iata(city: str):
+    alias = CITY_ALIASES.get(city.upper())
+    if alias:
+        return alias
     for info in AIRPORTS.values():
         if info.get("city") and info["city"].lower() == city.lower():
             return info["iata"]
+    return None
+
+
+def _search_iata_online(term: str):
+    """Attempt to find an IATA code via web search."""
+    queries = [f"codigo IATA {term}", f"IATA code {term}"]
+    for q in queries:
+        results = search_web(q, num_results=3)
+        for r in results:
+            text = f"{r.get('title','')} {r.get('snippet','')}"
+            m = re.search(r"\b([A-Z]{3})\b", text)
+            if m:
+                code = m.group(1)
+                if code in AIRPORTS:
+                    return code
     return None
 
 
@@ -20,11 +44,83 @@ def _ensure_iata(value: str):
     val = value.strip().upper()
     if re.fullmatch(r"[A-Z]{3}", val) and val in AIRPORTS:
         return val
-    return _city_to_iata(val)
+    code = _city_to_iata(val)
+    if code:
+        return code
+    # Fallback to web search for uncommon names like CDMX
+    return _search_iata_online(value)
 
-def search_flights(datos, exclude_ids=None, query=None):
+
+def search_web(query, num_results=5):
+    """Return a list of organic search results from Google via SerpAPI."""
+    params = {
+        "engine": "google",
+        "q": query,
+        "api_key": SERPAPI_KEY,
+        "num": num_results,
+    }
+    try:
+        resp = requests.get(SERP_ENDPOINT, params=params, timeout=20)
+        resp.raise_for_status()
+        data = resp.json()
+    except Exception:
+        return []
+
+    results = []
+    for item in data.get("organic_results", [])[:num_results]:
+        results.append(
+            {
+                "title": item.get("title"),
+                "link": item.get("link"),
+                "snippet": item.get("snippet"),
+            }
+        )
+    return results
+
+
+def _extract_city(text: str):
+    """Return first city name in text that maps to a known airport."""
+    for match in re.findall(r"[A-Z][a-zA-Z]+(?: [A-Z][a-zA-Z]+)*", text):
+        if _city_to_iata(match):
+            return match
+    return None
+
+
+def venue_city(venue: str):
+    """Try to resolve venue location to a city using web search."""
+    queries = [f"{venue} address", f"direccion de {venue}"]
+    for q in queries:
+        results = search_web(q, num_results=1)
+        if results:
+            text = f"{results[0].get('title','')} {results[0].get('snippet','')}"
+            city = _extract_city(text)
+            if city:
+                return city
+    return None
+
+def _parse_flight_entry(entry):
+    segments = entry.get("flights") or []
+    if not segments:
+        return None
+    first = segments[0]
+    last = segments[-1]
+    fid = entry.get("departure_token") or entry.get("booking_token")
+    fid = fid or f"{first.get('flight_number','')}_{first.get('departure_airport', {}).get('time','')}"
+    return {
+        "id": fid,
+        "airline": first.get("airline"),
+        "flight_number": first.get("flight_number"),
+        "departure_time": first.get("departure_airport", {}).get("time"),
+        "arrival_time": last.get("arrival_airport", {}).get("time"),
+        "price": entry.get("price"),
+    }
+
+
+def search_flights(datos, exclude_ids=None, query=None, deep_search=SERP_DEEP_SEARCH):
     """Search flights using SerpAPI Google Flights."""
     params = {"engine": "google_flights", "api_key": SERPAPI_KEY}
+    if deep_search:
+        params["deep_search"] = "true"
     if query:
         params["q"] = query
     else:
@@ -50,21 +146,33 @@ def search_flights(datos, exclude_ids=None, query=None):
         return [], "Error consultando SerpAPI."
 
     flights = []
-    for f in data.get("best_flights", []):
-        fid = f"{f.get('airline','')} {f.get('flight_number','')} {f.get('departing_at','')}"
-        if exclude_ids and fid in exclude_ids:
-            continue
-        flights.append({
-            "id": fid,
-            "airline": f.get("airline"),
-            "flight_number": f.get("flight_number"),
-            "departure_time": f.get("departing_at"),
-            "arrival_time": f.get("arriving_at"),
-            "price": f.get("price", {}).get("amount"),
-        })
+    for section in ["best_flights", "other_flights"]:
+        for entry in data.get(section, []):
+            flight = _parse_flight_entry(entry)
+            if not flight:
+                continue
+            if exclude_ids and flight["id"] in exclude_ids:
+                continue
+            flights.append(flight)
     if not flights:
         return [], "SerpAPI no devolvió vuelos."
     return flights, None
+
+
+def _parse_hotel_entry(entry):
+    name = entry.get("name")
+    if not name:
+        return None
+    rate = entry.get("rate_per_night") or {}
+    price = rate.get("extracted_lowest") or rate.get("extracted_before_taxes_fees")
+    if not price:
+        price = entry.get("extracted_price")
+    return {
+        "id": name,
+        "name": name,
+        "price": price,
+        "link": entry.get("link"),
+    }
 
 
 def search_hotels(datos, area, max_price, exclude_ids=None, query=None):
@@ -75,10 +183,8 @@ def search_hotels(datos, area, max_price, exclude_ids=None, query=None):
         "check_in_date": datos["start_date"],
         "check_out_date": datos.get("return_date") or datos["start_date"],
     }
-    if query:
-        params["q"] = query
-    else:
-        params["q"] = area
+    params["q"] = query or area
+
     try:
         resp = requests.get(SERP_ENDPOINT, params=params, timeout=20)
         resp.raise_for_status()
@@ -90,18 +196,16 @@ def search_hotels(datos, area, max_price, exclude_ids=None, query=None):
         return [], "Error consultando SerpAPI."
 
     hotels = []
-    for h in data.get("hotels_results", []):
-        hid = h.get("name")
-        if exclude_ids and hid in exclude_ids:
-            continue
-        price = h.get("price_night", {}).get("extracted")
-        if price and price <= max_price:
-            hotels.append({
-                "id": hid,
-                "name": h.get("name"),
-                "price": price,
-                "link": h.get("link"),
-            })
+    for section in ["ads", "properties"]:
+        for h in data.get(section, []):
+            hotel = _parse_hotel_entry(h)
+            if not hotel:
+                continue
+            if exclude_ids and hotel["id"] in exclude_ids:
+                continue
+            if hotel.get("price") and hotel["price"] <= max_price:
+                hotels.append(hotel)
+
     if not hotels:
         return [], "SerpAPI no devolvió hoteles."
     return hotels, None
@@ -113,15 +217,9 @@ def check_safety(area):
     ]
     snippets = []
     for q in queries:
-        params = {"engine": "google", "q": q, "api_key": SERPAPI_KEY}
-        try:
-            resp = requests.get(SERP_ENDPOINT, params=params, timeout=20)
-            resp.raise_for_status()
-            data = resp.json()
-        except Exception:
-            continue
-        if data.get("organic_results"):
-            snippet = data["organic_results"][0].get("snippet", "")
+        results = search_web(q, num_results=1)
+        if results:
+            snippet = results[0].get("snippet", "")
             if snippet:
                 snippets.append(snippet)
     info = " ".join(snippets)
@@ -133,17 +231,9 @@ def check_safety(area):
     return False, info or "No se pudo verificar."
 
 def find_better_area(area):
-    url = "https://serpapi.com/search.json"
-    params = {
-        "engine": "google",
-        "q": f"zonas seguras cerca de {area}",
-        "api_key": SERPAPI_KEY
-    }
-    resp = requests.get(url, params=params)
-    if resp.status_code == 200:
-        data = resp.json()
-        if 'organic_results' in data and data['organic_results']:
-            return data['organic_results'][0].get('title', area)
+    results = search_web(f"zonas seguras cerca de {area}", num_results=1)
+    if results:
+        return results[0].get("title", area)
     return area
 
 def handle_search_and_buttons(datos, state, event, client, say, doc_ref, max_lodging_override=None):
@@ -169,7 +259,13 @@ def handle_search_and_buttons(datos, state, event, client, say, doc_ref, max_lod
     if not state.get('hotel_selected'):
         region = get_region(datos['destination'])
         max_lodging = max_lodging_override or LODGING_LIMITS[state['level']][region]
-        area = datos.get('venue') or datos['destination']
+        area = datos['destination']
+        query = None
+        if datos.get('venue'):
+            city = venue_city(datos['venue'])
+            if city:
+                area = city
+            query = datos['venue']
 
         # --- Lógica de seguridad de zona ---
         is_safe, info = check_safety(area)
@@ -178,7 +274,7 @@ def handle_search_and_buttons(datos, state, event, client, say, doc_ref, max_lod
             say(f"La zona {area} podría no ser segura: {info}. Buscaré hoteles en {better_area} en su lugar.")
             area = better_area
 
-        hotels, err = search_hotels(datos, area, max_lodging, exclude_ids=state['seen_hotels'])
+        hotels, err = search_hotels(datos, area, max_lodging, exclude_ids=state['seen_hotels'], query=query)
         if err:
             say(err)
             return True


### PR DESCRIPTION
## Summary
- parse SerpApi hotel results from new `properties` output
- support ads and handle updated price fields
- enable deep search option for flights
- add generic `search_web` helper and use in safety checks
- resolve IATA codes via Google search when not found
- detect venue city for better hotel search

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6884278ab79c8325883acdbdb5d29c41