### PR TITLE
Add guidance on AI Overview extraction

### DIFF
--- a/extraccion.md
+++ b/extraccion.md
@@ -1,0 +1,11 @@
+# Ayuda de extracción
+
+TravelBot utiliza Gemini para interpretar la conversación y extraer los datos necesarios del viaje. Para complementar esta información preferimos usar la API **Google AI Overview** de SerpAPI en lugar de la búsqueda tradicional con `engine=google`. Primero se realiza una búsqueda para obtener `ai_overview.page_token` y luego se consulta `search?engine=google_ai_overview` con ese token.
+
+Esta API devuelve un resumen que facilita la obtención rápida de:
+
+- Códigos IATA de aeropuertos o ciudades.
+- Direcciones de lugares y sitios de interés.
+- Nivel de riesgo o seguridad de una zona o barrio.
+
+El resumen se analiza para extraer estas piezas y agilizar las consultas. Esta técnica se usa cuando no se encuentran los códigos IATA o se necesita validar si una zona es segura antes de sugerir hoteles.

--- a/extraccion.md
+++ b/extraccion.md
@@ -1,11 +1,11 @@
 # Ayuda de extracción
 
-TravelBot utiliza Gemini para interpretar la conversación y extraer los datos necesarios del viaje. Para complementar esta información preferimos usar la API **Google AI Overview** de SerpAPI en lugar de la búsqueda tradicional con `engine=google`. Primero se realiza una búsqueda para obtener `ai_overview.page_token` y luego se consulta `search?engine=google_ai_overview` con ese token.
+TravelBot utiliza Gemini para interpretar la conversación y extraer los datos necesarios del viaje. Para obtener información adicional, preferimos la API **Google AI Overview** de SerpAPI en lugar de `engine=google`. Primero se hace una búsqueda para conseguir `ai_overview.page_token` y luego se consulta el endpoint `search?engine=google_ai_overview` con ese token.
 
-Esta API devuelve un resumen que facilita la obtención rápida de:
+Esta API devuelve resúmenes de las páginas de resultados de Google, lo que facilita obtener rápidamente:
 
 - Códigos IATA de aeropuertos o ciudades.
 - Direcciones de lugares y sitios de interés.
 - Nivel de riesgo o seguridad de una zona o barrio.
 
-El resumen se analiza para extraer estas piezas y agilizar las consultas. Esta técnica se usa cuando no se encuentran los códigos IATA o se necesita validar si una zona es segura antes de sugerir hoteles.
+El resumen se analiza para extraer estos datos y acelerar las consultas. Se utiliza principalmente cuando no se encuentran los códigos IATA o se necesita validar la seguridad de una zona antes de sugerir hoteles.


### PR DESCRIPTION
## Summary
- explain that AI Overview should be used instead of regular Google search
- clarify how to use the page token to get IATA codes, addresses and safety info quickly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68843aa62d5083258c5290e890983798